### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "form-data-to-object": "^0.2.0",
     "lodash": "^3.10.1",
     "negotiator": "^0.6.0",
-    "node-uuid": "^1.4.7",
     "request": "^2.67.0",
     "sort-by": "^1.1.1",
     "type-is": "^1.6.10",
+    "uuid": "^3.0.0",
     "valid-url": "^1.0.9",
     "winston": "^2.2.0"
   },

--- a/src/fields/lib/file.js
+++ b/src/fields/lib/file.js
@@ -6,7 +6,7 @@
 let fs = require('fs');
 let path = require('path');
 let OS = require('os');
-let UUID = require('node-uuid');
+let UUID = require('uuid');
 
 let Restypie = require('../../');
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.